### PR TITLE
updated .env.example to not have empty strings and include vapi token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ AUTH_SECRET="put auth secret here"
 # Google Auth Provider
 GOOGLE_CLIENT_ID="put client id here"
 GOOGLE_CLIENT_SECRET="put client secret here"
+OPENAI_API_KEY="put open ai key here"
 VAPI_TOKEN="put vapi token here"
 
 # Prisma

--- a/.env.example
+++ b/.env.example
@@ -13,12 +13,13 @@
 # You can generate a new secret on the command line with:
 # npx auth secret
 # https://next-auth.js.org/configuration/options#secret
-AUTH_SECRET=""
+AUTH_SECRET="put auth secret here"
 
 
 # Google Auth Provider
-GOOGLE_CLIENT_ID=""
-GOOGLE_CLIENT_SECRET=""
+GOOGLE_CLIENT_ID="put client id here"
+GOOGLE_CLIENT_SECRET="put client secret here"
+VAPI_TOKEN="put vapi token here"
 
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env


### PR DESCRIPTION
Updated .env.example to not have empty strings and include vapi token